### PR TITLE
Adding support for more facebook message types

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,3 +4,5 @@ module.exports = {
   PluginVersion: 1,
   PluginClass: PluginClass
 }
+
+module.exports.proxy = require('./src/plugin')

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 const PluginClass = require('./src/connector')
+const ProxyClass = require('./src/proxy')
 
 module.exports = {
   PluginVersion: 1,
   PluginClass: PluginClass
 }
 
-module.exports.proxy = require('./src/plugin')
+module.exports.proxy = ProxyClass

--- a/src/connector.js
+++ b/src/connector.js
@@ -13,7 +13,7 @@ const Capabilities = {
   FBWEBHOOK_APPSECRET: 'FBWEBHOOK_APPSECRET'
 }
 const Defaults = {
-  [Capabilities.FBWEBHOOK_PAGEID]: "123456",
+  [Capabilities.FBWEBHOOK_PAGEID]: '123456',
   [Capabilities.FBWEBHOOK_TIMEOUT]: 10000
 }
 
@@ -111,7 +111,7 @@ class BotiumConnectorFbWebhook {
               botMsg.messageText = event.body.message.text
             }
             if (fbMessage.quick_replies) {
-              botMsg.buttons = botMsg.buttons || [];
+              botMsg.buttons = botMsg.buttons || []
               fbMessage.quick_replies.map(qr => {
                 botMsg.buttons.push({
                   text: qr.title,
@@ -122,7 +122,7 @@ class BotiumConnectorFbWebhook {
             if (fbMessage.attachment) {
               const attachment = fbMessage.attachment.payload
               switch (attachment.template_type) {
-                case 'generic': {
+                case 'generic':
                   botMsg.cards = botMsg.cards || []
                   attachment.elements.map(element => {
                     botMsg.cards.push({
@@ -131,12 +131,11 @@ class BotiumConnectorFbWebhook {
                       image: element.image_url && {
                         mediaUri: element.image_url
                       },
-                      buttons: element.buttons && element.buttons.map(button => ({text: button.title, payload: button.payload}))
+                      buttons: element.buttons && element.buttons.map(button => ({ text: button.title, payload: button.payload }))
                     })
                   })
-                }
-                break
-                case 'button': {
+                  break
+                case 'button':
                   botMsg.messageText = attachment.text
                   botMsg.buttons = botMsg.buttons || []
                   attachment.buttons.map(button => {
@@ -145,8 +144,7 @@ class BotiumConnectorFbWebhook {
                       payload: button.payload
                     })
                   })
-                }
-                break
+                  break
                 default:
                   // Types of attachment not supported list, media, receipt, airline_boardingpass
                   debug(`WARNING: recieved unsupported message from ${channel}, ignoring ${event}`)
@@ -214,9 +212,7 @@ class BotiumConnectorFbWebhook {
     const requestOptions = {
       uri: this.caps[Capabilities.FBWEBHOOK_WEBHOOKURL],
       method: 'POST',
-      headers: {
-        'Botium': true
-      },
+      headers: { Botium: true },
       body: msgContainer,
       json: true,
       timeout: this.caps[Capabilities.FBWEBHOOK_TIMEOUT]

--- a/src/connector.js
+++ b/src/connector.js
@@ -13,7 +13,7 @@ const Capabilities = {
   FBWEBHOOK_APPSECRET: 'FBWEBHOOK_APPSECRET'
 }
 const Defaults = {
-  [Capabilities.FBWEBHOOK_PAGEID]: 123456,
+  [Capabilities.FBWEBHOOK_PAGEID]: "123456",
   [Capabilities.FBWEBHOOK_TIMEOUT]: 10000
 }
 
@@ -106,48 +106,58 @@ class BotiumConnectorFbWebhook {
           const botMsg = { sender: 'bot', sourceData: event }
           const fbMessage = event.body.message
 
-          if (fbMessage.text) {
-            botMsg.messageText = event.body.message.text
-          }
-          if (fbMessage.quick_reply) {
-            botMsg.buttons = [{
-              text: fbMessage.text,
-              payload: fbMessage.quick_reply.payload
-            }]
-          }
-          if (fbMessage.attachment) {
-            const attachment = fbMessage.attachment.payload
-            switch (attachment.template_type) {
-              case 'generic': {
-                botMsg.cards = []
-                attachment.elements.map(element => {
-                  botMsg.cards.push({
-                    text: element.title,
-                    subtext: element.subtitle,
-                    image: element.image_url && {
-                      mediaUri: element.image_url
-                    },
-                    buttons: element.buttons && element.buttons.map(button => ({text: button.title, payload: button.payload}))
-                  })
-                })
-              }
-              case 'button': {
-                botMsg.buttons = []
-                attachment.buttons.map(button => {
-                  botMsg.buttons.push({
-                    text: button.title,
-                    payload: button.payload
-                  })
-                })
-              }
-              default:
-                // Types of attachment not supported list, media, receipt, airline_boardingpass
-                debug(`WARNING: recieved unsupported message from ${channel}, ignoring ${event}`)
+          if (fbMessage) {
+            if (fbMessage.text) {
+              botMsg.messageText = event.body.message.text
             }
-          }
+            if (fbMessage.quick_replies) {
+              botMsg.buttons = botMsg.buttons || [];
+              fbMessage.quick_replies.map(qr => {
+                botMsg.buttons.push({
+                  text: qr.title,
+                  payload: qr.payload
+                })
+              })
+            }
+            if (fbMessage.attachment) {
+              const attachment = fbMessage.attachment.payload
+              switch (attachment.template_type) {
+                case 'generic': {
+                  botMsg.cards = botMsg.cards || []
+                  attachment.elements.map(element => {
+                    botMsg.cards.push({
+                      text: element.title,
+                      subtext: element.subtitle,
+                      image: element.image_url && {
+                        mediaUri: element.image_url
+                      },
+                      buttons: element.buttons && element.buttons.map(button => ({text: button.title, payload: button.payload}))
+                    })
+                  })
+                }
+                break
+                case 'button': {
+                  botMsg.messageText = attachment.text
+                  botMsg.buttons = botMsg.buttons || []
+                  attachment.buttons.map(button => {
+                    botMsg.buttons.push({
+                      text: button.title,
+                      payload: button.payload
+                    })
+                  })
+                }
+                break
+                default:
+                  // Types of attachment not supported list, media, receipt, airline_boardingpass
+                  debug(`WARNING: recieved unsupported message from ${channel}, ignoring ${event}`)
+              }
+            }
 
-          debug(`Received a message to queue ${channel}: ${JSON.stringify(botMsg)}`)
-          setTimeout(() => this.queueBotSays(botMsg), 100)
+            debug(`Received a message to queue ${channel}: ${JSON.stringify(botMsg)}`)
+            setTimeout(() => this.queueBotSays(botMsg), 100)
+          } else {
+            debug(`WARNING: recieved non message fb event from ${channel}, ignoring ${event}`)
+          }
 
           this._sendToBot({
             sourceData: {

--- a/src/connector.js
+++ b/src/connector.js
@@ -107,6 +107,26 @@ class BotiumConnectorFbWebhook {
 
           botMsg.messageText = event.body.message.text
 
+          let attachmentMsg = event.body.message.attachment
+
+          if(attachmentMsg) {
+            if(attachmentMsg.type == 'template') {
+              botMsg.cards = [] 
+              attachmentMsg.payload.elements.map(element => {
+                let card = {
+                  text: element.title,
+                  subtext: element.subtitle,
+                  image: element.image_url && {
+                    mediaUri: element.image_url
+                  },
+                  buttons: element.buttons && element.buttons.map(b => ({text: b.title, payload: b.payload}))
+                }
+
+                botMsg.cards.push(card)
+              })
+            }
+          }
+
           debug(`Received a message to queue ${channel}: ${JSON.stringify(botMsg)}`)
           setTimeout(() => this.queueBotSays(botMsg), 100)
 
@@ -165,7 +185,9 @@ class BotiumConnectorFbWebhook {
     const requestOptions = {
       uri: this.caps[Capabilities.FBWEBHOOK_WEBHOOKURL],
       method: 'POST',
-      headers: {},
+      headers: {
+        'Botium': true
+      },
       body: msgContainer,
       json: true,
       timeout: this.caps[Capabilities.FBWEBHOOK_TIMEOUT]


### PR DESCRIPTION
Add support for the following message types:

- [Quick Replies](https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies)
- Cards ([Generic](https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic), [Button](https://developers.facebook.com/docs/messenger-platform/send-messages/template/button))

Also adding small modification to default value type of 'FBWEBHOOK_PAGEID' to be a string which is inline with fb dev docs - https://developers.facebook.com/docs/messenger-platform/reference/webhook-events/messages