### PR TITLE
Adding support for FB Messenger Referall Links

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,13 @@ class BotiumConnectorFbWebhook {
                 payload: msg.buttons[0].payload || msg.buttons[0].text
               }
             }
-          } else {
+          } 
+          else if (msg.referral) {
+            msgData.sourceData = {
+              referral: msg.referral
+            }
+          }
+          else {
             msgData.sourceData = {
               message: {
                 text: msg.messageText


### PR DESCRIPTION
Messenger allows for the passing of referrals through the use of `ref` GET parameters in an `m.me` link.

This PR implements referral functionality for Messenger deeplinks into Botium (requires a separate `setUserInput` function to be useful).